### PR TITLE
Made for Catcoin Team Servers Only and Binary Build Patches

### DIFF
--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -41,7 +41,7 @@ RUN wget -nc https://dl.winehq.org/wine-builds/Release.key && \
         apt-key add Release.key && \
         rm Release.key && \
     wget -nc https://dl.winehq.org/wine-builds/winehq.key && \
-        echo "78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6 winehq.key" | sha256sum -c - && \
+        echo "d965d646defe94b3dfba6d5b4406900ac6c81065428bf9d9303ad7a72ee8d1b8 winehq.key" | sha256sum -c - && \
         apt-key add winehq.key && \
         rm winehq.key && \
     apt-add-repository https://dl.winehq.org/wine-builds/debian/ && \

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -3,12 +3,13 @@
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs
 
 import sys
-for i, x in enumerate(sys.argv):
+"""for i, x in enumerate(sys.argv):
     if x == '--name':
         cmdline_name = sys.argv[i+1]
         break
 else:
-    raise Exception('no name')
+    raise Exception('no name')"""
+cmdline_name = "electrum-ltc-4.3.2"
 
 home = 'C:\\electrum-ltc\\'
 

--- a/electrum_ltc/servers.json
+++ b/electrum_ltc/servers.json
@@ -1,44 +1,7 @@
 {
-    "46.101.3.154": {
+    "ltc.electrum-cat.org": {
         "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4.2"
-    },
-    "backup.electrum-ltc.org": {
-        "pruning": "-",
-        "s": "443",
-        "t": "50001",
-        "version": "1.4.2"
-    },
-    "electrum-ltc.bysh.me": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4.2"
-    },
-    "electrum.ltc.xurious.com": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4.2"
-    },
-    "electrum.privateservers.network": {
-        "pruning": "-",
-        "s": "50005",
-        "t": "50004",
-        "version": "1.4.2"
-    },
-    "electrum1.cipig.net": {
-        "pruning": "-",
-        "s": "20063",
-        "t": "10063",
-        "version": "1.4.2"
-    },
-    "ltc.rentonisk.com": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4.2"
+        "s": "9103",
+        "version": "1.16.0"
     }
 }


### PR DESCRIPTION
1. Replace all servers with Cotcoin Core Team's ElectrumX Servers.
2. Fix WineHQ checksum key mismatch
3. Dirty patch Build-Wine (Windows Executable Build) code by hardcoding the value of cmdline_name. to avoid "no name" Exception
